### PR TITLE
Improvements to structure, support for SmartThings local processing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2016 - 2018, Sten Feldman
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,13 @@ all:	start cpu drivers misc pan link burn
 
 start:	$(OUTPUT) \
 	$(OUTPUT)/start08.o \
+	$(OUTPUT)/util.o \
 	$(OUTPUT)/main.o
 
 $(OUTPUT)/start08.o: ./src/start08.c
+	$(CC) $(CFLAGS) -ObjN="$@" -Lm="$@.d" -LmCfg=xilmou $<
+
+$(OUTPUT)/util.o: ./src/util.c
 	$(CC) $(CFLAGS) -ObjN="$@" -Lm="$@.d" -LmCfg=xilmou $<
 
 $(OUTPUT)/main.o: ./src/main.c
@@ -283,6 +287,7 @@ link:
 	"$(OUTPUT)/pan/zigbee/zigbee_zcl.o" \
 	"$(OUTPUT)/pan/zigbee/zigbee_zdo.o" \
 	"$(OUTPUT)/start08.o" \
+	"$(OUTPUT)/util.o" \
 	"$(OUTPUT)/main.o" \
 	"$(HC08C)/lib/$(HC08C_LIB)"\) \
 	-O"$(OUTPUT)/$(APP_NAME).abs"

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ The following defines can be altered in `custom.h` prior to compilation to chang
 |  Name | Description | Default |
 | ------| ----------- | ------- |
 | `PXBEE_TRIGGER_IGNORE_BROADCAST` | When enabled, ignores broadcast commands and reacts only when unicast messages are sent to the specific address (ignores All On/All Off commands). | Enabled |
+| `ZCL_MANUFACTURER` | The reported manufacturer string. For SmartThings local execution support without custom device handler, set this to "Leviton". | "PXBee" |
+| `ZCL_MODEL` | The reported model string. For SmartThings local execution support without custom device handler, set this to "ZSS-10". | "Trigger" |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pxbee-trigger
 
-Programmable XBee Trigger that is ZigBee Home Automation profile compliant. The testing of this feature branch is carried out using [SmartThings](https://www.smartthings.com) Hub and a default ZigBee device handler.
+Programmable XBee Trigger that is ZigBee Home Automation profile compliant. The testing of this feature is carried out using [SmartThings](https://www.smartthings.com) Hub and a default ZigBee device handler.
 
 ## Bill of Materials
 
@@ -38,3 +38,25 @@ clusterId: 0x0006,
 profileId: 0x0104,
 command: 0x01
 ```
+
+## Settings
+
+The following defines can be altered in `custom.h` prior to compilation to change the behavior how the Trigger works:
+
+|  Name | Description | Default |
+| ------| ----------- | ------- |
+| `PXBEE_TRIGGER_IGNORE_BROADCAST` | When enabled, ignores broadcast commands and reacts only when unicast messages are sent to the specific address (ignores All On/All Off commands). | Enabled |
+
+## License
+
+This project is based on [exsilium/pxbee-blink-led](https://github.com/exsilium/pxbee-blink-led) boilerplate and includes the full [Digi](http://www.digi.com) XBee SDK version 1.6.0 sources.
+
+Includes the necessary build binaries:
+```
+HI-CROSS+ ANSI-C Compiler for HC08 V-5.0.39, Dec 13 2011
+HI-CROSS+ SmartLinker V-5.0.48, Dec 13 2011
+HI-CROSS+ Burner V-5.0.16, Dec 13 2011
+(c) Copyright Freescale 1987-2010
+```
+
+If not otherwise noted, the added code is [BSD licensed](LICENSE).

--- a/include/custom.h
+++ b/include/custom.h
@@ -16,7 +16,12 @@
 #define XBEE_PARAM_EO       1
 #define XBEE_PARAM_KY       "5A6967426565416C6C69616E63653039"
 
-/* Reported manufacturer and model in basic cluster */
+/* Reported manufacturer and model in basic cluster
+ *
+ * For SmartThings local execution without custom device handler, set the following:
+ * - ZCL_MANUFACTURER "Leviton"
+ * - ZCL_MODEL        "ZSS-10"
+ */
 #define ZCL_MANUFACTURER    "PXBee"
 #define ZCL_MODEL           "Trigger"
 

--- a/include/custom.h
+++ b/include/custom.h
@@ -6,7 +6,7 @@
  *
  */
  
-/* Additional XBee settings */
+/* Additional XBee settings for SmartThings compatibility */
 #define XBEE_PARAM_ZS       2
 #define XBEE_PARAM_NJ       0x5A
 #define XBEE_PARAM_NH       0x1E
@@ -16,8 +16,14 @@
 #define XBEE_PARAM_EO       1
 #define XBEE_PARAM_KY       "5A6967426565416C6C69616E63653039"
 
+/* Reported manufacturer and model in basic cluster */
+#define ZCL_MANUFACTURER    "PXBee"
+#define ZCL_MODEL           "Trigger"
+
 /* Ignore On command received via Broadcast message */
 #define PXBEE_TRIGGER_IGNORE_BROADCAST
+
+/* Settings END */
  
 #include <zigbee/zdo.h>
 
@@ -29,13 +35,13 @@ extern wpan_ep_state_t custom_ha_ep_state;
 
  /* With this macro the prototypes of clusters' callbacks and extern variables are included in endpoints.c
   * Array custom_ep_data_clusters[] is declared in main.c
-  * Function custom_ep_default_cluster() is implemented in main.c */
+  * Function custom_ep_basic_cluster() is implemented in main.c */
 #define EP_INCLUDE_DECLARATIONS extern const wpan_cluster_table_entry_t custom_ep_clusters[];  \
-                                int custom_ep_default_cluster(const wpan_envelope_t FAR *, void FAR *);
+                                int custom_ep_basic_cluster(const wpan_envelope_t FAR *, void FAR *);
 
  /* This is a wpan_endpoint_table_entry_t structure, see its declaration in aps.h, the '{}' are because they
   * will be included in endpoints_table[] in endpoints.c */
-#define ADDITIONAL_ENDPOINTS {CUSTOM_ENDPOINT, CUSTOM_EP_PROFILE, custom_ep_default_cluster, &custom_ha_ep_state, 0x0002, 0x00, custom_ep_clusters}, \
+#define ADDITIONAL_ENDPOINTS {CUSTOM_ENDPOINT, CUSTOM_EP_PROFILE, custom_ep_basic_cluster, &custom_ha_ep_state, 0x0002, 0x00, custom_ep_clusters}, \
                              ZDO_ENDPOINT(zdo_ep_state)
 
  /* This macro is automatically defined if Process Incoming frames, Node Discovery Support or Over-the-Air

--- a/include/util.h
+++ b/include/util.h
@@ -1,0 +1,1 @@
+uint8_t* appendStringChar(uint8_t* dest, const char* str);

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,19 @@
+/* Generic Helper/Utility functions */
+
+#include <types.h>
+
+// Contribution by ST Community member - gazor
+uint8_t* appendStringChar(uint8_t* dest, const char* str)
+{
+  // Write string, preceeded by length byte, no termination character
+  size_t len = 0;
+  for(;;)
+  {
+    uint8_t c = (uint8_t) str[len];
+    if(c == 0) break;
+    dest[1+len] = c;
+    len++;
+  }
+  dest[0] = (uint8_t) len;
+  return dest + 1 + len;
+}


### PR DESCRIPTION
- custom_ep_default_cluster() has been renamed to custom_ep_basic_cluster() because naming matters and it's about handling the ZigBee basic cluster comms
- custom_ep_rx_cluster() -> custom_ep_rx_on_off_cluster()
- new custom_ep_rx_notimpl_cluster()
- Reports new nonimplemented clusters as capability (0003,0004,0005)
- Utility function for easier string manipulation, thanks ST member [gazor](https://community.smartthings.com/u/gazor)!
- LICENSE added for clarity
- README updated
- This is WIP and meant for testing ST local operability